### PR TITLE
Update require statement for TextField

### DIFF
--- a/lib/CurrencyField.js
+++ b/lib/CurrencyField.js
@@ -12,7 +12,7 @@ var _react = require('react');
 
 var _react2 = _interopRequireDefault(_react);
 
-var _textField = require('material-ui/lib/text-field');
+var _textField = require('material-ui/TextField');
 
 var _textField2 = _interopRequireDefault(_textField);
 


### PR DESCRIPTION
Hey, great input.

I noticed that the require statement is throwing the following error in v 0.18.0, at least when using es6 import statements.
```
ERROR in ./~/react-materialui-currency/lib/CurrencyField.js
Module not found: Error: Can't resolve 'material-ui/lib/text-field' in 'node_modules/react-materialui-currency/lib'
```

I made the quick change to fix the import path